### PR TITLE
Example: Fapp docker lib curl

### DIFF
--- a/.github/workflows/build_fapp_curl_example.yml
+++ b/.github/workflows/build_fapp_curl_example.yml
@@ -1,0 +1,35 @@
+name: Build and test the fapp/curl_example ACAP
+
+on:
+  push:
+    paths:
+      - "fapp/curl_example/**"
+      - ".github/workflows/build_fapp_curl_example.yml"
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        arch: ["armv7hf", "aarch64"]
+    steps:
+      - name: Checkout the code
+        uses: actions/checkout@v3
+
+      - name: Install FApp CLI and login
+        uses: fixedit-ai/install-fappcli-action@main
+        with:
+          token: ${{ secrets.FAPP_TOKEN }}
+
+      - name: Build ACAP application
+        uses: fixedit-ai/build-eap-action@main
+        with:
+          arch: ${{ matrix.arch }}
+          dir: fapp/curl_example
+          fapp-manifest: fapp/curl_example/fapp-manifest.json
+
+      - name: Validate the content of the ACAP .eap file
+        uses: fixedit-ai/test-eap-action@main
+        with:
+          arch: ${{ matrix.arch }}
+          app-path: "fapp/curl_example/*.eap"

--- a/fapp/README.md
+++ b/fapp/README.md
@@ -1,0 +1,8 @@
+# FApp example applications
+These example ACAPs make use of the FApp (FixedIT Application) ecosystem, including prebuilt libraries and command line tools that make building applications quicker and easier.
+
+## fapp/hello_world
+This is the most basic example of an Hello World application that is using the foundational `libfapp` library for logging and signal handling. The application is built using `fappcli-build` and `fappcli-deploy`.
+
+## fapp/curl_example
+This is a slightly more complex example that also makes use of the precompiled libraries cURL and openssl. The application is also using a simple version of `fapp-manifest.json` to persist good default arguments to the `fappcli` commands.

--- a/fapp/curl_example/Dockerfile
+++ b/fapp/curl_example/Dockerfile
@@ -1,0 +1,27 @@
+ARG CAM_ARCH
+ARG VERSION=1.7
+ARG REPO=axisecp
+ARG SDK=acap-native-sdk
+
+FROM ${REPO}/${SDK}:${VERSION}-${CAM_ARCH} as builder
+ENV SDK_ENV="/opt/axis/acapsdk/environment-setup*"
+
+WORKDIR /opt/app
+COPY ./app .
+
+# Image with only the application binary built
+FROM builder as app-binaries
+ARG FAPP_BIN_NAME
+ARG FAPP_APP_NAME
+ARG FAPP_MAKE_OPTS
+ARG FAPP_CFLAGS
+ARG FAPP_LDFLAGS
+RUN . $SDK_ENV && make $FAPP_MAKE_OPTS
+
+# Image with the application .eap package built
+FROM builder as app-package
+ARG FAPP_BIN_NAME
+ARG FAPP_APP_NAME
+ARG FAPP_CFLAGS
+ARG FAPP_LDFLAGS
+RUN . $SDK_ENV && acap-build .

--- a/fapp/curl_example/Dockerfile
+++ b/fapp/curl_example/Dockerfile
@@ -1,27 +1,26 @@
-ARG CAM_ARCH
-ARG VERSION=1.7
-ARG REPO=axisecp
-ARG SDK=acap-native-sdk
+# These paths to docker images are set by the builder tool
+ARG FAPP_IMAGE_BUILDER_BASE
+ARG FAPP_IMAGE_OPENSSL
+ARG FAPP_IMAGE_CURL
 
-FROM ${REPO}/${SDK}:${VERSION}-${CAM_ARCH} as builder
-ENV SDK_ENV="/opt/axis/acapsdk/environment-setup*"
+# Load the prebuilt libraries for curl so that we can make
+# web requests from the app. Openssl is needed if we want to
+# use https.
+FROM ${FAPP_IMAGE_CURL} as library-curl
+FROM ${FAPP_IMAGE_OPENSSL} as library-openssl
 
+# We use FixedIT Application base image - the version of the SDK
+# is defined by the arguments to the build command.
+FROM ${FAPP_IMAGE_BUILDER_BASE} as builder
+
+# Copy the prebuilt libraries from the library images
+COPY --from=library-openssl /library /opt/app
+COPY --from=library-curl /library /opt/app
+
+# Copy app source code
 WORKDIR /opt/app
 COPY ./app .
 
-# Image with only the application binary built
-FROM builder as app-binaries
-ARG FAPP_BIN_NAME
-ARG FAPP_APP_NAME
-ARG FAPP_MAKE_OPTS
-ARG FAPP_CFLAGS
-ARG FAPP_LDFLAGS
-RUN . $SDK_ENV && make $FAPP_MAKE_OPTS
-
-# Image with the application .eap package built
-FROM builder as app-package
-ARG FAPP_BIN_NAME
-ARG FAPP_APP_NAME
-ARG FAPP_CFLAGS
-ARG FAPP_LDFLAGS
-RUN . $SDK_ENV && acap-build .
+# Append library license files to the app license file
+# This will be visible in the application tab in the cameras UI.
+RUN cat license/* >> LICENSE

--- a/fapp/curl_example/README.md
+++ b/fapp/curl_example/README.md
@@ -1,0 +1,24 @@
+# FApp Hello World application
+This application shows a minimal example of an application that is using the FApp (FixedIT Application) standard library and being built with the FApp CLI tool.
+
+The application is using the signal handler from `libfapp`, this sets up the application to handle signals like `SIGINT`, `SIGFAULT` and many more such that the application can release any peripherals and make any clean-up necessary. The application runs a Glib event loop and registers a callback that will stop the event loop whenever a signal is received.
+
+The application is using `libfapp` for logging which logs messages to both the standard output but also the system log. This allows retrival of log messages from the Axis camera web interface but also makes it easy to run the application manually during debugging or development such that the log messages are printed directly to the terminal.
+
+## Build the application
+The application uses a `Dockerfile` which specifies the build environment. The application is build with the FApp CLI tool, e.g.:
+```bash
+fappcli-build build . --lib libfapp
+```
+
+You can also build the application, install it in an available camera and run it interactivily in the terminal with a single command:
+```bash
+fappcli-deploy run . --lib libfapp
+```
+This command will look in your `~/.fapp` config file for cameras, find a camera that is currently available and check the CPU architecture of the camera. The application is then built for the cameras architecture, and installed in the camera using the VAPIX API. If the application is already installed, only the files that has been updated since last is copied to the camera (for faster deployment). Once this is done, the application is run over ssh with the terminal's pty connected to the
+application.
+
+The FApp CLI tool will automatically set build arguments for the build, such as:
+* `FAPP_BIN_NAME`: The name of the application binary to build based on the manifest file
+* `FAPP_APP_NAME`: The display name of the application based on the manifest file
+* `FAPP_CFLAGS` and `FAPP_LDFLAGS`: Other compilation flags needed for the build

--- a/fapp/curl_example/README.md
+++ b/fapp/curl_example/README.md
@@ -1,23 +1,79 @@
-# FApp Hello World application
-This application shows a minimal example of an application that is using the FApp (FixedIT Application) standard library and being built with the FApp CLI tool.
+# FApp cURL application
+This application shows another example of how the `fappcli` tool and the precompiled FApp libraries can be used to make application development for the Axis cameras easier.
+
+## Build and install
+The application is built with `fappcli-build` tool. All the build options such as prebuilt libraries to pull when building are specified in the `fapp-manifest.json` file.
+
+To build the application, simply run:
+```bash
+fappcli-build build .
+```
+
+The tool will fetch all the libraries and requirements needed and build the application. It will also extract the `.eap` file and the build log from the Docker container. The build log is found in the file `build.log`. If the build would fail due to e.g. invalid C code or errors in the `Dockerfile`, the build root will be extracted from the docker container and can be found in the `build_root` directory. This simplifies the troubleshooting process.
+
+Select ACAP SDK 3 by running:
+```bash
+fappcli-build build . --sdk-name acap-sdk
+```
+or ACAP Native SDK 4 with:
+```bash
+fappcli-build build --sdk-name acap-native-sdk
+```
+The latest minor of the SDK will be used but you can also specify one specific with:
+```bash
+fappcli-build build --sdk-name acap-native-sdk --sdk-version 1.7
+```
+These options can also be specified in the `fapp-manifest.json` file to avoid repeating the same commands on every build.
+
+To build and install the application, run:
+```bash
+fappcli-deploy install .
+```
+The tool will automatically select one of the cameras connected to your computer, find the architecture for that camera and build the application for that architecture. The tool will then use VAPIX to install the application in the camera. You can also run:
+```bash
+fappcli-deploy run .
+```
+which will not only build and install the application but also run it in the camera and pipe all the output to the terminal. To select a specific camera, add the option `--camera <CAM_NAME>` or to select any camera with a specific architecture, type: `--arch <ARCH>`.
+
+## Using precompiled libraries
+A library specified with the command line argument `--lib` or specified in the `fapp-manifest.json` file will be fetched as a docker image and the corresponding docker build-arg will be set. The format of the build-arg is `FAPP_IMAGE_<LIBRARY_NAME>`, e.g. specifying `--lib curl` will make the library available as `FAPP_IMAGE_CURL`. The deployment structure of all libraries are the same:
+```
+/
+├── library
+│   ├── include
+│   │   └── <HEADER_FILES>
+│   ├── lib
+│   │   └── <SHARED_OBJECTS>
+│   ├── license
+│   │   └── <LICENCE_FILES>
+│   ├── bin
+│   │   └── <OPTIONAL_CLI_TOOLS>
+```
+
+To use the library code, copy headers and libraries to a directory search by the compiler:
+```Docker
+ARG FAPP_IMAGE_CURL
+FROM ${FAPP_IMAGE_CURL} as library-curl
+
+FROM ${FAPP_IMAGE_BUILDER_BASE} as builder
+COPY --from=library-curl /library /opt/app
+```
+
+To correctly include all the libraries license information in your applications license page in the Axis UI, cat the content of all libraries license files to the end of your applications license file:
+```docker
+RUN cat license/* >> LICENSE
+```
+
+The `LICENSE` files and the `lib` directory will always be included in the `.eap` file. To include the `bin` folder with camera CLI tools, specify the argument `--extra-package-files bin` or add the same line to the `fapp-manifest.json` file.
+
+## Logging and signal handling with libfapp
+The application does also make use of `libfapp`. In difference from the other libraries this is distributed as source code. The `fappcli` tool will automatically download the source code if the `--lib libfapp` option is specified or if it is present in the `fapp-manifest.json` file.
 
 The application is using the signal handler from `libfapp`, this sets up the application to handle signals like `SIGINT`, `SIGFAULT` and many more such that the application can release any peripherals and make any clean-up necessary. The application runs a Glib event loop and registers a callback that will stop the event loop whenever a signal is received.
 
 The application is using `libfapp` for logging which logs messages to both the standard output but also the system log. This allows retrival of log messages from the Axis camera web interface but also makes it easy to run the application manually during debugging or development such that the log messages are printed directly to the terminal.
 
-## Build the application
-The application uses a `Dockerfile` which specifies the build environment. The application is build with the FApp CLI tool, e.g.:
-```bash
-fappcli-build build . --lib libfapp
-```
-
-You can also build the application, install it in an available camera and run it interactivily in the terminal with a single command:
-```bash
-fappcli-deploy run . --lib libfapp
-```
-This command will look in your `~/.fapp` config file for cameras, find a camera that is currently available and check the CPU architecture of the camera. The application is then built for the cameras architecture, and installed in the camera using the VAPIX API. If the application is already installed, only the files that has been updated since last is copied to the camera (for faster deployment). Once this is done, the application is run over ssh with the terminal's pty connected to the
-application.
-
+## Other build parameters
 The FApp CLI tool will automatically set build arguments for the build, such as:
 * `FAPP_BIN_NAME`: The name of the application binary to build based on the manifest file
 * `FAPP_APP_NAME`: The display name of the application based on the manifest file

--- a/fapp/curl_example/app/LICENSE
+++ b/fapp/curl_example/app/LICENSE
@@ -1,0 +1,202 @@
+
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [2022] [FixedIT Consulting AB]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/fapp/curl_example/app/Makefile
+++ b/fapp/curl_example/app/Makefile
@@ -7,7 +7,8 @@ PKGS = glib-2.0
 CFLAGS += $(FAPP_CFLAGS) -Iinclude \
           -DAPP_NAME="\"$(FAPP_APP_NAME)\""
 
-LDFLAGS += -L./lib -Wl,-rpath,'$$ORIGIN/lib' $(FAPP_LDFLAGS)
+LDFLAGS += -L./lib -Wl,-rpath,'$$ORIGIN/lib' $(FAPP_LDFLAGS) \
+           -lcurl ./lib/libssl.so ./lib/libcrypto.so
 
 CFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKGS))
 LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
@@ -22,4 +23,4 @@ all: $(FAPP_BIN_NAME)
 	$(CC) -c -o $@ $(CFLAGS) $<
 
 $(FAPP_BIN_NAME): $(C_OBJS)
-	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@
+	$(CC) $^ $(LDLIBS) -o $@ $(LDFLAGS)

--- a/fapp/curl_example/app/Makefile
+++ b/fapp/curl_example/app/Makefile
@@ -1,0 +1,25 @@
+LIBFAPP_LIBRARY_PATH = fapp/
+
+C_FILES = $(wildcard src/*.c) $(wildcard src/$(LIBFAPP_LIBRARY_PATH)/*.c)
+
+PKGS = glib-2.0
+
+CFLAGS += $(FAPP_CFLAGS) -Iinclude \
+          -DAPP_NAME="\"$(FAPP_APP_NAME)\""
+
+LDFLAGS += -L./lib -Wl,-rpath,'$$ORIGIN/lib' $(FAPP_LDFLAGS)
+
+CFLAGS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --cflags $(PKGS))
+LDLIBS += $(shell PKG_CONFIG_PATH=$(PKG_CONFIG_PATH) pkg-config --libs $(PKGS))
+
+CFLAGS += -Wall -Werror -pedantic
+
+C_OBJS = $(C_FILES:.c=.o)
+
+all: $(FAPP_BIN_NAME)
+
+%.o: %.c
+	$(CC) -c -o $@ $(CFLAGS) $<
+
+$(FAPP_BIN_NAME): $(C_OBJS)
+	$(CC) $(LDFLAGS) $^ $(LDLIBS) -o $@

--- a/fapp/curl_example/app/manifest.json
+++ b/fapp/curl_example/app/manifest.json
@@ -1,0 +1,18 @@
+{
+    "schemaVersion": "1.1",
+    "acapPackageConf": {
+        "setup": {
+            "friendlyName": "curl_example",
+            "appName": "curl_example",
+            "vendor": "FixedIT Consulting AB",
+            "embeddedSdkVersion": "2.18",
+            "user": {
+                "group": "sdk",
+                "username": "sdk"
+            },
+            "vendorUrl": "fixedit.ai",
+            "runMode": "never",
+            "version": "0.0.1"
+        }
+    }
+}

--- a/fapp/curl_example/app/src/main.c
+++ b/fapp/curl_example/app/src/main.c
@@ -1,7 +1,81 @@
 #include <stdlib.h>
 
+#include <curl/curl.h>
 #include <fapp/logging.h> // Logging to both stdout and system log
 #include <fapp/misc.h>    // For signal handling
+#include <glib.h>
+
+// Use the cameras certificate authority to validate certs
+#define SSL_CA_PATH "/etc/ssl/certs"
+
+
+/*
+ * This function is called by libcurl when it has data to write and
+ * appends the data to a GString buffer.
+ */
+static size_t write_curl_response_to_gstring(void *contents, size_t size,
+                                             size_t nmemb, void *data) {
+  GString *json_string = (GString *)data;
+
+  size_t realsize = size * nmemb;
+  g_string_append_len(json_string, (char *)contents, realsize);
+
+  return realsize;
+}
+
+
+/*
+ * This function uses libcurl to get json data from a web API.
+ * The data is returned as a GString that must be freed by the caller.
+ * Returns NULL on error.
+ */
+static GString *web_get_json_data(const char *url) {
+  GString *ret = NULL;
+
+  CURL *curl;
+  CURLcode curl_retval;
+
+  GString *json_string = g_string_new(NULL);
+
+  curl = curl_easy_init();
+  curl_easy_setopt(curl, CURLOPT_URL, url);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 1L);
+  curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
+  curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_response_to_gstring);
+  curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)json_string);
+  curl_easy_setopt(curl, CURLOPT_CAPATH, SSL_CA_PATH);
+
+  curl_retval = curl_easy_perform(curl);
+  if (curl_retval != CURLE_OK) {
+    fapp_logger_log(LOG_ERR, "curl_easy_perform() failed: %s\n",
+                    curl_easy_strerror(curl_retval));
+    g_string_free(json_string, TRUE);
+    goto end;
+  }
+
+  ret = json_string;
+
+end:
+  curl_easy_cleanup(curl);
+
+  return ret;
+}
+
+
+/*
+ * This function gets json data from a web API and prints it.
+ */
+static void get_and_print_json() {
+  GString *json_string =
+      web_get_json_data("https://jsonplaceholder.typicode.com/todos/1");
+  if (json_string == NULL) {
+    fapp_logger_log(LOG_ERR, "Failed to get json data");
+    return;
+  }
+  fapp_logger_log(LOG_INFO, "JSON data: %s", json_string->str);
+  g_string_free(json_string, TRUE);
+}
+
 
 int main(int argc, char **argv) {
   fapp_logger_init(APP_NAME);
@@ -11,18 +85,18 @@ int main(int argc, char **argv) {
   // error condition such as segfaults is detected.
   fapp_signal_handler_init();
 
-  // Create a glib event loop and register a callback to stop it
-  // whenever a signal is recevied
-  GMainLoop *loop = g_main_loop_new(NULL, FALSE);
-  fapp_signal_handler_register_gmainloop(loop);
+  // Initialize cURL that will be used for HTTPS requests to get json data from
+  // web APIs
+  curl_global_init(CURL_GLOBAL_DEFAULT);
 
   // Write hello world!
   fapp_logger_log(LOG_INFO, "Hello world!");
 
-  // Run main loop until receiving a signal
-  while (!fapp_do_stop) {
-    g_main_loop_run(loop);
-  }
+  // Get json data from a web API and print it
+  get_and_print_json();
+
+  // Clean up
+  curl_global_cleanup();
 
   fapp_logger_log(LOG_INFO, "App exited.");
   return EXIT_SUCCESS;

--- a/fapp/curl_example/app/src/main.c
+++ b/fapp/curl_example/app/src/main.c
@@ -1,0 +1,29 @@
+#include <stdlib.h>
+
+#include <fapp/logging.h> // Logging to both stdout and system log
+#include <fapp/misc.h>    // For signal handling
+
+int main(int argc, char **argv) {
+  fapp_logger_init(APP_NAME);
+
+  // Setup a signal handler so that we can perform clean-up and
+  // return of peripherals when receiving a signal or when an
+  // error condition such as segfaults is detected.
+  fapp_signal_handler_init();
+
+  // Create a glib event loop and register a callback to stop it
+  // whenever a signal is recevied
+  GMainLoop *loop = g_main_loop_new(NULL, FALSE);
+  fapp_signal_handler_register_gmainloop(loop);
+
+  // Write hello world!
+  fapp_logger_log(LOG_INFO, "Hello world!");
+
+  // Run main loop until receiving a signal
+  while (!fapp_do_stop) {
+    g_main_loop_run(loop);
+  }
+
+  fapp_logger_log(LOG_INFO, "App exited.");
+  return EXIT_SUCCESS;
+}

--- a/fapp/curl_example/fapp-manifest.json
+++ b/fapp/curl_example/fapp-manifest.json
@@ -1,0 +1,7 @@
+{
+    "build": {
+        "lib": ["libfapp", "curl", "openssl"],
+        "sdk_name": "acap-native-sdk",
+        "extra_package_files": ["bin"]
+    }
+}

--- a/fapp/hello_world/app/src/main.c
+++ b/fapp/hello_world/app/src/main.c
@@ -25,5 +25,6 @@ int main(int argc, char **argv) {
   }
 
   fapp_logger_log(LOG_INFO, "App exited.");
+
   return EXIT_SUCCESS;
 }


### PR DESCRIPTION
Add a new example app that shows how to use the `fappcli` tool to build apps with prebuilt libraries.