### PR TITLE
Bump to new openssl release

### DIFF
--- a/fapp/curl_example/app/src/main.c
+++ b/fapp/curl_example/app/src/main.c
@@ -6,9 +6,6 @@
 #include <glib.h>
 #include <json-glib/json-glib.h>
 
-// Use the cameras certificate authority to validate certs
-#define SSL_CA_PATH "/etc/ssl/certs"
-
 /* This struct defines the content of the todo API that we are getting data from
  */
 typedef struct todo_item {
@@ -51,7 +48,6 @@ static GString *web_get_json_data(const char *url) {
   curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
   curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, write_curl_response_to_gstring);
   curl_easy_setopt(curl, CURLOPT_WRITEDATA, (void *)json_string);
-  curl_easy_setopt(curl, CURLOPT_CAPATH, SSL_CA_PATH);
 
   curl_retval = curl_easy_perform(curl);
   if (curl_retval != CURLE_OK) {

--- a/fapp/curl_example/fapp-manifest.debug.json
+++ b/fapp/curl_example/fapp-manifest.debug.json
@@ -1,6 +1,7 @@
 {
     "build": {
         "lib": ["libfapp", "curl", "openssl", "json-glib"],
+	"docker_lib_version": "2023-12-13_17-06-13",
         "sdk_name": "acap-native-sdk",
         "extra_package_files": ["bin"],
         "build_arg": [

--- a/fapp/curl_example/fapp-manifest.json
+++ b/fapp/curl_example/fapp-manifest.json
@@ -1,6 +1,7 @@
 {
     "build": {
         "lib": ["libfapp", "curl", "openssl", "json-glib"],
+	"docker_lib_version": "2023-12-13_17-06-13",
         "sdk_name": "acap-native-sdk"
     }
 }

--- a/fapp/sentry_example/app/src/main.c
+++ b/fapp/sentry_example/app/src/main.c
@@ -10,10 +10,6 @@
 #include <vdo-error.h>
 #include <vdo-stream.h>
 
-// Use the cameras certificate authority to validate certs
-// This is needed since sentry reports over encrypted https
-#define SSL_CA_PATH "/etc/ssl/certs/ca-certificates.crt"
-
 /* Log a simple telemetry message to the Sentry.io server */
 void sentry_log_message(const char *level, const char *message,
                         const char *description) {
@@ -170,7 +166,6 @@ static void fapp_sentry_init() {
   sentry_options_set_database_path(options, APP_DIR "/localdata/sentry");
   sentry_options_set_release(options, APP_VERSION);
   sentry_options_set_debug(options, SENTRY_DEBUG);
-  sentry_options_set_ca_certs(options, SSL_CA_PATH);
 
   // Set the sampling rate for performance metrics. Since we measure
   // the analytics of every frame we will get ~25 samples per second.

--- a/fapp/sentry_example/fapp-manifest.debug.json
+++ b/fapp/sentry_example/fapp-manifest.debug.json
@@ -1,6 +1,7 @@
 {
     "build": {
         "lib": ["libfapp", "sentry", "curl", "openssl"],
+	"docker_lib_version": "2023-12-13_17-06-13",
         "sdk_name": "acap-native-sdk",
         "build_arg": [
             "VERBOSE_OUTPUT=true",

--- a/fapp/sentry_example/fapp-manifest.json
+++ b/fapp/sentry_example/fapp-manifest.json
@@ -1,6 +1,7 @@
 {
     "build": {
         "lib": ["libfapp", "sentry", "curl", "openssl"],
+	"docker_lib_version": "2023-12-13_17-06-13",
         "sdk_name": "acap-native-sdk",
         "build_arg": [
             "SENTRY_DSN=https://REPLACE-ME",


### PR DESCRIPTION
The new release uses the default CA bundle in the camera so we no longer need to specify the path.